### PR TITLE
Fix Xbox enter button (A)

### DIFF
--- a/spatial_navigation.js
+++ b/spatial_navigation.js
@@ -863,6 +863,8 @@
           if (!fireEvent(currentFocusedElement, 'enter-down')) {
             return preventDefault();
           }
+          preventDefault();
+          currentFocusedElement.click();
         }
       }
       return;


### PR DESCRIPTION
## 📖 Description
Even if the Xbox enter button (A) key code was in the `selectKeyCodes`, pressing on it wasn't triggering an enter/click action.

By preventing the default action and then, manually triggering the click action, it will work with any button in the list.